### PR TITLE
fix method of CleanWebpackPlugin of webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,9 @@ const baseWebpack = {
     new webpack.DefinePlugin({
       'process.env.WEBPACK_MODE': JSON.stringify(process.env.WEBPACK_MODE)
     }),
-    new CleanWebpackPlugin(['dist']),
+    new CleanWebpackPlugin({
+      cleanOnceBeforeBuildPatterns: ['dist']
+    }),
     new HtmlWebpackPlugin({  
       hash: true, 
       template: './src/index.pug'


### PR DESCRIPTION
When running `npm start`, the error below was shown, after the fix in CleanWebpackPlugin, the problem was solved.
![Screen Shot 2019-04-29 at 20 06 15](https://user-images.githubusercontent.com/943553/56932464-568c3000-6aba-11e9-876a-d5444479bd19.png)

